### PR TITLE
Upgrade AF to 4.12.0

### DIFF
--- a/amqp-spring-boot-3-integrationtests/pom.xml
+++ b/amqp-spring-boot-3-integrationtests/pom.xml
@@ -38,7 +38,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <axon.version>4.11.2</axon.version>
+        <axon.version>4.12.0</axon.version>
         <testcoontainers.version>1.21.3</testcoontainers.version>
 
         <jar-plugin.version>3.4.2</jar-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
             ${project.basedir}/../coverage-report/target/site/jacoco-aggregate/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
 
-        <axon.version>4.11.2</axon.version>
+        <axon.version>4.12.0</axon.version>
         <rabbitmq.version>5.25.0</rabbitmq.version>
 
         <spring.version>5.3.39</spring.version>


### PR DESCRIPTION
This pull request upgrades the Axon Framework version to 4.12.0.